### PR TITLE
Minor Typos causing Build Errors on MacOSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.o
+*.lst
 core
 client
 server

--- a/v3/build
+++ b/v3/build
@@ -1,2 +1,2 @@
-c -l vtx_test*.c
+c -l -lzmq -lczmq vtx_test*.c
 

--- a/v3/vtx.c
+++ b/v3/vtx.c
@@ -26,7 +26,6 @@
 
 #include "vtx.h"
 
-
 //  ---------------------------------------------------------------------
 //  Structure of our class
 //  Not threadsafe, do not access from multiple threads
@@ -117,7 +116,11 @@ vtx_register (vtx_t *self, char *scheme, zthread_attached_fn *driver_fn, Bool ve
         driver = s_driver_new (self, scheme, driver_fn, verbose);
     else {
         rc = -1;
+#ifdef ENOTUNIQ
         errno = ENOTUNIQ;
+		// BSD and hence darwin doesn't support ENOTUNIQ, with no logical replacement
+		// Leaving this blank for now
+#endif
     }
     return rc;
 }

--- a/v3/vtx.h
+++ b/v3/vtx.h
@@ -28,6 +28,7 @@
 #define __VTX_INCLUDED__
 
 #include "czmq.h"
+#include <sys/errno.h>
 
 //  Types of routing per driver socket
 #define VTX_ROUTING_NONE        0       //  No output routing allowed

--- a/v3/vtx_tcp.c
+++ b/v3/vtx_tcp.c
@@ -1234,7 +1234,7 @@ s_handle_io_error (char *reason)
     ||  errno == EPROTO
     ||  errno == ENOPROTOOPT
     ||  errno == EHOSTDOWN
-    ||  errno == ENONET
+    ||  errno == ENOENT
     ||  errno == EHOSTUNREACH
     ||  errno == EOPNOTSUPP
     ||  errno == ENETUNREACH

--- a/v3/vtx_udp.c
+++ b/v3/vtx_udp.c
@@ -476,19 +476,37 @@ binding_require (vocket_t *vocket, char *address)
             zclock_log ("E: bind failed: invalid address '%s'", address);
             self->exception = TRUE;
         }
+<<<<<<< HEAD
         if (!self->exception) {
             if (bind (self->handle,
                 (const struct sockaddr *) &addr, IN_ADDR_SIZE) == -1) {
+=======
+
+
+		// Case external address (1)
+		// Try binding to address with bind(2), and if that fails, 
+		// set the exception flag (skipping case (2))
+        if (!self->exception) {
+			if (bind (self->handle, // http://beej.us/guide/bgnet/output/html/multipage/bindman.html
+					  (const struct sockaddr *) &addr, IN_ADDR_SIZE) == -1) {
+>>>>>>> 43a2dec... Fixed typo in vtx.c, and added preproc test for ENOTUNIQ (not available on BSD)
                 zclock_log ("E: bind failed: '%s'", strerror (errno));
                 self->exception = TRUE;
             }
         }
+<<<<<<< HEAD
+=======
+
+		// Case local address (2) 
+>>>>>>> 43a2dec... Fixed typo in vtx.c, and added preproc test for ENOTUNIQ (not available on BSD)
         if (!self->exception) {
             //  Catch input on handle
             zmq_pollitem_t item = { NULL, self->handle, ZMQ_POLLIN, 0 };
             zloop_poller (self->driver->loop, &item, s_binding_input, vocket);
         }
         //* End transport-specific work
+
+		// If cannot bind after both attempts, free binding
         if (self->exception) {
             free (self->address);
             free (self);
@@ -622,7 +640,10 @@ peering_send_msg (peering_t *self, zmsg_t *msg, int flags)
     assert (self);
     byte *data;
     size_t size = zmsg_encode (msg, &data);
+	// note and NOM refers to a payload
     int rc = peering_send (self, VTX_UDP_NOM, data, size, flags);
+
+	// Update counter and clean
     self->vocket->outgoing++;
     free (data);
     return rc;
@@ -1275,7 +1296,7 @@ s_handle_io_error (char *reason)
     ||  errno == EPROTO
     ||  errno == ENOPROTOOPT
     ||  errno == EHOSTDOWN
-    ||  errno == ENONET
+	||  errno == ENOENT
     ||  errno == EHOSTUNREACH
     ||  errno == EOPNOTSUPP
     ||  errno == ENETUNREACH


### PR DESCRIPTION
Fixed typo in vtx.c: "ENOENT" was misspelled as "ENONET"

Added preprocessor test for ENOTUNIQ, which is not available on BSD and MacOSX and was causing build errors
